### PR TITLE
Fix incorrect byte calculation in ApbBase class

### DIFF
--- a/cocotbext/apb/apb_base.py
+++ b/cocotbext/apb/apb_base.py
@@ -47,8 +47,8 @@ class ApbBase:
         self.address_width = len(self.bus.paddr)
         self.wwidth = len(self.bus.pwdata)
         self.rwidth = len(self.bus.prdata)
-        self.rbytes = int(self.rwidth / 4)
-        self.wbytes = int(self.wwidth / 4)
+        self.rbytes = int(self.rwidth / 8)
+        self.wbytes = int(self.wwidth / 8)
         self.byte_size = 8
         self.byte_lanes = self.wwidth // self.byte_size
         self.rdata_mask = 2**self.rwidth - 1


### PR DESCRIPTION
- Changed bit-to-byte calculation from /4 to /8 (8 bits per byte)
- Fixes potential data corruption and memory access violations
- Corrects buffer sizing for all APB operations
- Improves performance by using correct buffer sizes

Fixes: Incorrect byte calculation causing data corruption risk