### PR TITLE
Fix APB4Bus and APB5Bus optional_signals list mutation bug

### DIFF
--- a/cocotbext/apb/apb_bus.py
+++ b/cocotbext/apb/apb_bus.py
@@ -47,11 +47,10 @@ class Apb4Bus(Apb3Bus):
         if signals is None:
             signals = self._signals
         if optional_signals is None:
-            optional_signals = self._optional_signals.extend(
-                ["pstrb", "pprot", "pslverr"]
-            )
+            optional_signals = self._optional_signals.copy()
+            optional_signals.extend(["pstrb", "pprot", "pslverr"])
         super().__init__(
-            entity, prefix, signals, optional_signals=self._optional_signals, **kwargs
+            entity, prefix, signals, optional_signals=optional_signals, **kwargs
         )
 
 
@@ -66,16 +65,15 @@ class Apb5Bus(Apb4Bus):
         if signals is None:
             signals = self._signals
         if optional_signals is None:
-            optional_signals = self._optional_signals.extend(
-                [
-                    "pwakeup",
-                    "pauser",
-                    "pwuser",
-                    "pruser",
-                    "pbuser",
-                    "pnse",
-                ]
-            )
+            optional_signals = self._optional_signals.copy()
+            optional_signals.extend([
+                "pwakeup",
+                "pauser",
+                "pwuser",
+                "pruser",
+                "pbuser",
+                "pnse",
+            ])
         super().__init__(
-            entity, prefix, signals, optional_signals=self._optional_signals, **kwargs
+            entity, prefix, signals, optional_signals=optional_signals, **kwargs
         )


### PR DESCRIPTION
- Fixed incorrect use of extend() method that was setting optional_signals to None
- Properly copy and extend optional signals list for APB4Bus and APB5Bus
- Restores full APB4 and APB5 protocol support
- Fixes runtime errors when accessing optional signals

Fixes: APB4Bus and APB5Bus optional_signals set to None due to extend() returning None